### PR TITLE
hashlib_constructor.py

### DIFF
--- a/src/python/detectors/hashlib_constructor/hashlib_constructor.py
+++ b/src/python/detectors/hashlib_constructor/hashlib_constructor.py
@@ -1,30 +1,17 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-# {fact rule=hashlib-constructor@v1.0 defects=1}
-def constructor_noncompliant():
-    import hashlib
-
-    text = "ExampleString"
-
-    # Noncompliant: uses the new() constructor instead of the hashlib
-    # constructor, which is slower.
-    result = hashlib.new('sha256', text.encode())
-
-    print("The hexadecimal equivalent of SHA256 is : ")
-    print(result.hexdigest())
+# {fact rule=deprecated-method@v1.0 defects=1}
+def deprecated_method_noncompliant(url):
+    import botocore.vendored.requests as requests
+    # Noncompliant: uses the deprecated botocore vendored method.
+    return requests.get(url)
 # {/fact}
 
 
-# {fact rule=hashlib-constructor@v1.0 defects=0}
-def constructor_compliant():
-    import hashlib
-
-    text = "ExampleString"
-
-    # Compliant: uses the hashlib constructor over the new(), which is faster.
-    result = hashlib.sha256(text.encode())
-
-    print("The hexadecimal equivalent of SHA256 is : ")
-    print(result.hexdigest())
+# {fact rule=deprecated-method@v1.0 defects=0}
+def deprecated_method_compliant(url, sigv4auth):
+    import requests
+    # Compliant: avoids using the deprecated methods.
+    return requests.get(url, auth=sigv4auth).text
 # {/fact}


### PR DESCRIPTION
 Here are a few suggestions to improve the code:

```python
# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
# SPDX-License-Identifier: Apache-2.0

import hashlib
import requests

# Use hashlib module directly instead of new()
def hash_data(data):
    return hashlib.sha256(data.encode()).hexdigest() 

# Avoid vendored/deprecated botocore requests  
def get_url(url):
    response = requests.get(url)
    return response.text
```

The main improvements:

- Import hashlib module directly and use hashlib.sha256() instead of hashlib.new() which is slower.

- Avoid using the vendored/deprecated botocore requests module. Directly use requests module instead.

- Use more descriptive function names like hash_data and get_url instead of generic names like deprecated_method.

- Remove the fact tags since they don't seem relevant in this context.

Let me know if you have any other questions!