### PR TITLE
hashlib_constructor.py

### DIFF
--- a/src/python/detectors/hashlib_constructor/hashlib_constructor.py
+++ b/src/python/detectors/hashlib_constructor/hashlib_constructor.py
@@ -1,17 +1,21 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-# {fact rule=deprecated-method@v1.0 defects=1}
-def deprecated_method_noncompliant(url):
-    import botocore.vendored.requests as requests
-    # Noncompliant: uses the deprecated botocore vendored method.
-    return requests.get(url)
+# {fact rule=lambda-client-reuse@v1.0 defects=1}
+def lambda_handler_noncompliant(event, context):
+    import boto3
+    # Noncompliant: recreates AWS clients in each lambda invocation.
+    client = boto3.client('s3')
+    response = client.list_buckets()
 # {/fact}
 
 
-# {fact rule=deprecated-method@v1.0 defects=0}
-def deprecated_method_compliant(url, sigv4auth):
-    import requests
-    # Compliant: avoids using the deprecated methods.
-    return requests.get(url, auth=sigv4auth).text
+# {fact rule=lambda-client-reuse@v1.0 defects=0}
+import boto3
+client = boto3.client('s3')
+
+
+def lambda_handler_compliant(event, context):
+    # Compliant: uses the cached client.
+    response = client.list_buckets()
 # {/fact}


### PR DESCRIPTION
 Here are some suggestions to improve the code based on the recommendation:

```python
# Import hashlib module
import hashlib

# Use hashlib.sha256() instead of hashlib.new()
hash_obj = hashlib.sha256()

# Update hash_obj with data to hash
hash_obj.update(b"Hello world") 

# Get the hex digest
hex_digest = hash_obj.hexdigest()

print(hex_digest)
```

The key changes:

- Import the hashlib module directly instead of using new()
- Construct a sha256 hash object using hashlib.sha256()
- Use the constructed hash object to update with data and generate the digest

This avoids constructing a new hash object each time and utilizes the faster hashlib module constructors directly.

For the lambda code, it looks good - the lambda_handler_compliant function shows the recommended practice of reusing the boto3 client rather than re-creating it each time. No suggestions for improvement there.